### PR TITLE
test: allow paths with periods

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,7 +51,7 @@ def test_main_nonexistent_config(tmp_path: Path) -> None:
     with pytest.raises(
         SystemExit,
         match=(
-            r"\x1b\[.*mERROR:\x1b\[0m [A-Za-z0-9/\\:_-]+"
+            r"\x1b\[.*mERROR:\x1b\[0m [A-Za-z0-9/\\\.:_-]+"
             r"nonexistent\.toml does not exist\x1b\[0m"
         ),
     ), patch("sys.argv", ["script", "--config", str(tmp_path / "nonexistent.toml")]):


### PR DESCRIPTION
The test for nonexistent config was failing on nix builds on macos since there was a period in the path.
This is a valid character for a filepath so I allowed them in the regex
